### PR TITLE
Remove devDepencies. Kill duplicates.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,7 @@
   "dependencies": {
     "bower": "^1.3.12",
     "grunt": "^0.4.5",
-    "grunt-contrib-sass": "^0.8.1",
-    "react": "^0.11.2"
-  },
-  "devDependencies": {
-    "grunt": "^0.4.5",
+    "react": "^0.11.2",
     "grunt-browserify": "^3.0.1",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-concat": "^0.5.0",


### PR DESCRIPTION
Don't see the need for a separate dependencies & devDependencies. Might as well merge them. At the moment there are duplicates between the two, just creates confusion.